### PR TITLE
Fix compiler warnings about unsafe memory lifetimes

### DIFF
--- a/herald/herald/Sensor/Payload/Extended/ExtendedData.swift
+++ b/herald/herald/Sensor/Payload/Extended/ExtendedData.swift
@@ -93,9 +93,14 @@ public class ConcreteExtendedDataV1 : ExtendedData {
         
         var input: [Float16] = [value]
         var output: [UInt8] = [0,0]
-        var sourceBuffer = vImage_Buffer(data: &input, height: 1, width: 1, rowBytes: MemoryLayout<Float16>.size)
-        var destinationBuffer = vImage_Buffer(data: &output, height: 1, width: 1, rowBytes: MemoryLayout<UInt16>.size)
-        vImageConvert_Planar16FtoPlanar8(&sourceBuffer, &destinationBuffer, 0)
+
+        input.withUnsafeMutableBytes { inputBytes in
+            output.withUnsafeMutableBytes { outputBytes in
+                var sourceBuffer = vImage_Buffer(data: inputBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<Float16>.size)
+                var destinationBuffer = vImage_Buffer(data: outputBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<UInt16>.size)
+                vImageConvert_Planar16FtoPlanar8(&sourceBuffer, &destinationBuffer, 0)
+            }
+        }
         
         payloadData.append(output[0].bigEndian)
         payloadData.append(output[1].bigEndian)
@@ -107,9 +112,14 @@ public class ConcreteExtendedDataV1 : ExtendedData {
         
         var input: [Float] = [value]
         var output: [UInt8] = [0,0,0,0]
-        var sourceBuffer = vImage_Buffer(data: &input, height: 1, width: 1, rowBytes: MemoryLayout<Float>.size)
-        var destinationBuffer = vImage_Buffer(data: &output, height: 1, width: 1, rowBytes: MemoryLayout<UInt32>.size)
-        vImageConvert_PlanarFtoPlanar8(&sourceBuffer, &destinationBuffer, Float.greatestFiniteMagnitude, Float.leastNonzeroMagnitude, 0)
+
+        input.withUnsafeMutableBytes { inputBytes in
+            output.withUnsafeMutableBytes { outputBytes in
+                var sourceBuffer = vImage_Buffer(data: inputBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<Float>.size)
+                var destinationBuffer = vImage_Buffer(data: outputBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<UInt32>.size)
+                vImageConvert_PlanarFtoPlanar8(&sourceBuffer, &destinationBuffer, Float.greatestFiniteMagnitude, Float.leastNonzeroMagnitude, 0)
+            }
+        }
         payloadData.append(output[0].bigEndian)
         payloadData.append(output[1].bigEndian)
         payloadData.append(output[2].bigEndian)

--- a/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
+++ b/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
@@ -290,9 +290,14 @@ private class F {
     fileprivate static func binary16(_ value: Float) -> Binary16 {
         var source: [Float] = [value]
         var target: [UInt16] = [0]
-        var sourceBuffer = vImage_Buffer(data: &source, height: 1, width: 1, rowBytes: MemoryLayout<Float>.size)
-        var targetBuffer = vImage_Buffer(data: &target, height: 1, width: 1, rowBytes: MemoryLayout<UInt16>.size)
-        vImageConvert_PlanarFtoPlanar16F(&sourceBuffer, &targetBuffer, 0)
+
+        source.withUnsafeMutableBytes { sourceBytes in
+            target.withUnsafeMutableBytes { targetBytes in
+                var sourceBuffer = vImage_Buffer(data: sourceBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<Float>.size)
+                var targetBuffer = vImage_Buffer(data: targetBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<UInt16>.size)
+                vImageConvert_PlanarFtoPlanar16F(&sourceBuffer, &targetBuffer, 0)
+            }
+        }
         let binary16 = Binary16(target[0])
         return binary16
     }
@@ -302,9 +307,14 @@ private class F {
     fileprivate static func float(_ value: Binary16) -> Float {
         var source: [UInt16] = [value]
         var target: [Float] = [0]
-        var sourceBuffer = vImage_Buffer(data: &source, height: 1, width: 1, rowBytes: MemoryLayout<UInt16>.size)
-        var targetBuffer = vImage_Buffer(data: &target, height: 1, width: 1, rowBytes: MemoryLayout<Float>.size)
-        vImageConvert_Planar16FtoPlanarF(&sourceBuffer, &targetBuffer, 0)
+
+        source.withUnsafeMutableBytes { sourceBytes in
+            target.withUnsafeMutableBytes { targetBytes in
+                var sourceBuffer = vImage_Buffer(data: sourceBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<UInt16>.size)
+                var targetBuffer = vImage_Buffer(data: targetBytes.baseAddress, height: 1, width: 1, rowBytes: MemoryLayout<Float>.size)
+                vImageConvert_Planar16FtoPlanarF(&sourceBuffer, &targetBuffer, 0)
+            }
+        }
         let float = target[0]
         return float
     }


### PR DESCRIPTION
[Who] As a Developer

[What] I want third-party code to be free of warnings

[Value] So that I can be confident in its stability and so that my own warnings do not get lost in the noise

---

I'm not entirely familiar with the unmanaged memory APIs in Swift but this seemed to be like the simplest way to get the correct pointer type with a defined lifetime.

It does seem exceedingly strange to be using image APIs to convert floating point values to raw bytes and vice-versa however, and there are some typing inconsistencies in the existing code as well.

Assuming Swift uses a standard memory representation for floating-point values that is cross-compatible with the Android and C++ projects, it would probably be much simpler to go through `Data` instead of needing the Accelerate framework.