### PR TITLE
Self-calibrated distance model

### DIFF
--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5NRR4P5W72;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -407,7 +407,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5NRR4P5W72;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -407,7 +407,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS/AppDelegate.swift
+++ b/Herald-for-iOS/AppDelegate.swift
@@ -1,7 +1,7 @@
 //
 //  AppDelegate.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/Herald-for-iOS/Log.swift
+++ b/Herald-for-iOS/Log.swift
@@ -1,7 +1,7 @@
 //
 //  Log.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/Herald-for-iOS/ModeSelectionViewController.swift
+++ b/Herald-for-iOS/ModeSelectionViewController.swift
@@ -1,7 +1,7 @@
 //
 //  ModeSelectionViewController.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/Herald-for-iOS/PhoneModeViewController.swift
+++ b/Herald-for-iOS/PhoneModeViewController.swift
@@ -1,7 +1,7 @@
 //
 //  ViewController.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/Herald-for-iOS/PhoneModeViewController.swift
+++ b/Herald-for-iOS/PhoneModeViewController.swift
@@ -135,7 +135,7 @@ class PhoneModeViewController: UIViewController, SensorDelegate, UITableViewData
         // Distance estimation
         analysisProviderManager.add(SmoothedLinearModelAnalyser(interval: 1, smoothingWindow: 60, model: smoothedLinearModel))
         analysisDelegateManager.add(analysisDelegate)
-        analysisRunner = AnalysisRunner(analysisProviderManager, analysisDelegateManager, defaultListSize: 120)
+        analysisRunner = AnalysisRunner(analysisProviderManager, analysisDelegateManager, defaultListSize: 1200)
     }
 
     @objc func willEnterForeground() {

--- a/Herald-for-iOS/TargetDetailsViewController.swift
+++ b/Herald-for-iOS/TargetDetailsViewController.swift
@@ -1,7 +1,7 @@
 //
 //  TargetDetailsViewController.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/Herald-for-iOS/VenueDiaryEventCell.swift
+++ b/Herald-for-iOS/VenueDiaryEventCell.swift
@@ -1,7 +1,7 @@
 //
 //  VenueDiaryEventCell.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 //

--- a/Herald-for-iOS/VenueDiaryViewController.swift
+++ b/Herald-for-iOS/VenueDiaryViewController.swift
@@ -1,7 +1,7 @@
 //
 //  VenueDiaryViewController.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/Herald-for-iOS/VenueModeViewController.swift
+++ b/Herald-for-iOS/VenueModeViewController.swift
@@ -1,7 +1,7 @@
 //
 //  VenueModeViewController.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		6F52D50A257C4F750097DD92 /* ExtendedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F52D509257C4F750097DD92 /* ExtendedData.swift */; };
 		6FBC6F2025867508001A86CE /* DataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC6F1F25867508001A86CE /* DataExtensionTests.swift */; };
 		6FE142FB2565C39A0084A59C /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE142FA2565C39A0084A59C /* Device.swift */; };
+		B61B1C98263AE69300FA20B0 /* TextFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61B1C97263AE69300FA20B0 /* TextFileTests.swift */; };
+		B61B1C9E263AFACC00FA20B0 /* RssiHistogramTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61B1C9D263AFACC00FA20B0 /* RssiHistogramTests.swift */; };
+		B61B1CA2263B12FE00FA20B0 /* SelfCalibratedModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61B1CA1263B12FE00FA20B0 /* SelfCalibratedModel.swift */; };
+		B61B1CA6263B165F00FA20B0 /* SelfCalibratedModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61B1CA5263B165F00FA20B0 /* SelfCalibratedModelTests.swift */; };
 		B637EF55251E55E60072D238 /* Herald.h in Headers */ = {isa = PBXBuildFile; fileRef = B637EF53251E55E60072D238 /* Herald.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B637EF79251E56320072D238 /* BLESensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF5E251E56320072D238 /* BLESensor.swift */; };
 		B637EF7A251E56320072D238 /* BLEDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF5F251E56320072D238 /* BLEDatabase.swift */; };
@@ -98,6 +102,10 @@
 		6F52D509257C4F750097DD92 /* ExtendedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExtendedData.swift; path = herald/Sensor/Payload/Extended/ExtendedData.swift; sourceTree = SOURCE_ROOT; };
 		6FBC6F1F25867508001A86CE /* DataExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensionTests.swift; sourceTree = "<group>"; };
 		6FE142FA2565C39A0084A59C /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Device.swift; path = herald/Sensor/Device.swift; sourceTree = SOURCE_ROOT; };
+		B61B1C97263AE69300FA20B0 /* TextFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFileTests.swift; sourceTree = "<group>"; };
+		B61B1C9D263AFACC00FA20B0 /* RssiHistogramTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssiHistogramTests.swift; sourceTree = "<group>"; };
+		B61B1CA1263B12FE00FA20B0 /* SelfCalibratedModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SelfCalibratedModel.swift; path = herald/Sensor/Analysis/Algorithms/Distance/SelfCalibratedModel.swift; sourceTree = SOURCE_ROOT; };
+		B61B1CA5263B165F00FA20B0 /* SelfCalibratedModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfCalibratedModelTests.swift; sourceTree = "<group>"; };
 		B637EF50251E55E60072D238 /* Herald.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Herald.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B637EF53251E55E60072D238 /* Herald.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Herald.h; sourceTree = "<group>"; };
 		B637EF54251E55E60072D238 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -335,6 +343,9 @@
 				B6C483E526318AED0007BFD1 /* SampleListTests.swift */,
 				B6C483E92631A87C0007BFD1 /* RangesTests.swift */,
 				B6C484062631EFA90007BFD1 /* AnalysisRunnerTests.swift */,
+				B61B1C97263AE69300FA20B0 /* TextFileTests.swift */,
+				B61B1C9D263AFACC00FA20B0 /* RssiHistogramTests.swift */,
+				B61B1CA5263B165F00FA20B0 /* SelfCalibratedModelTests.swift */,
 			);
 			path = HeraldTests;
 			sourceTree = "<group>";
@@ -377,6 +388,7 @@
 			children = (
 				B6C483F32631D4520007BFD1 /* FowlerBasic.swift */,
 				B6C4841E2633444B0007BFD1 /* SmoothedLinearModel.swift */,
+				B61B1CA1263B12FE00FA20B0 /* SelfCalibratedModel.swift */,
 			);
 			path = Distance;
 			sourceTree = "<group>";
@@ -539,6 +551,7 @@
 				B6F7460025571475003567B7 /* SimplePayloadDataMatcher.swift in Sources */,
 				B6C483F42631D4520007BFD1 /* FowlerBasic.swift in Sources */,
 				B637EF7A251E56320072D238 /* BLEDatabase.swift in Sources */,
+				B61B1CA2263B12FE00FA20B0 /* SelfCalibratedModel.swift in Sources */,
 				B6EEC22D25B44A8800D1CDF9 /* Mobility.swift in Sources */,
 				B6C4840F2632C7660007BFD1 /* AnalysisDelegate.swift in Sources */,
 				B637EF79251E56320072D238 /* BLESensor.swift in Sources */,
@@ -592,12 +605,15 @@
 				B6F74609255714C2003567B7 /* SocialDistanceTests.swift in Sources */,
 				D301023D25B8DD8300598DF4 /* ExtendedDataTests.swift in Sources */,
 				6F52D505257C47820097DD92 /* BeaconPayloadDataSupplierTests.swift in Sources */,
+				B61B1CA6263B165F00FA20B0 /* SelfCalibratedModelTests.swift in Sources */,
 				B6C484072631EFA90007BFD1 /* AnalysisRunnerTests.swift in Sources */,
 				B6F7460A255714C2003567B7 /* SimplePayloadDataMatcherTests.swift in Sources */,
 				6FBC6F2025867508001A86CE /* DataExtensionTests.swift in Sources */,
 				B6C483C72630B1CD0007BFD1 /* SampleTests.swift in Sources */,
 				6F273A4C258631AF0090B3B5 /* VenueDiaryEventTests.swift in Sources */,
 				B6F7460C255714C2003567B7 /* InteractionsTests.swift in Sources */,
+				B61B1C9E263AFACC00FA20B0 /* RssiHistogramTests.swift in Sources */,
+				B61B1C98263AE69300FA20B0 /* TextFileTests.swift in Sources */,
 				B6F7460B255714C2003567B7 /* BloomFilterTests.swift in Sources */,
 				B69F189D25B8A6AB001CC891 /* BLEAdvertParserTests.swift in Sources */,
 				B69FA4C325C2FD3B005E1E00 /* PseudoDeviceAddressTests.swift in Sources */,

--- a/herald/HeraldTests/AnalysisRunnerTests.swift
+++ b/herald/HeraldTests/AnalysisRunnerTests.swift
@@ -121,7 +121,7 @@ class AnalysisRunnerTests: XCTestCase {
         srcData.push(secondsSinceUnixEpoch: 60, value: RSSI(-68))
         let src = DummyRSSISource(SampledID(1234), srcData)
         
-        let distanceAnalyser = SmoothedLinearModelAnalyser(interval: 10, smoothingWindow: TimeInterval.minute, intercept: -17.7275, coefficient: -0.2754)
+        let distanceAnalyser = SmoothedLinearModelAnalyser(interval: 10, smoothingWindow: TimeInterval.minute, model: SmoothedLinearModel(intercept: -17.7275, coefficient: -0.2754))
         let myDelegate = DummyDistanceDelegate()
         
         let adm = AnalysisDelegateManager([myDelegate])

--- a/herald/HeraldTests/BLEAdvertParserTests.swift
+++ b/herald/HeraldTests/BLEAdvertParserTests.swift
@@ -1,7 +1,7 @@
 //
 //  BLEAdvertParserTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/BeaconPayloadDataSupplierTests.swift
+++ b/herald/HeraldTests/BeaconPayloadDataSupplierTests.swift
@@ -1,7 +1,7 @@
 //
 //  BeaconPayloadDataSupplierTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/BloomFilterTests.swift
+++ b/herald/HeraldTests/BloomFilterTests.swift
@@ -1,7 +1,7 @@
 //
 //  BloomFilterTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/DataExtensionTests.swift
+++ b/herald/HeraldTests/DataExtensionTests.swift
@@ -1,7 +1,7 @@
 //
 //  DataExtensionTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/ExtendedDataTests.swift
+++ b/herald/HeraldTests/ExtendedDataTests.swift
@@ -1,7 +1,7 @@
 //
 //  ExtendedDataTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/InteractionsTests.swift
+++ b/herald/HeraldTests/InteractionsTests.swift
@@ -1,7 +1,7 @@
 //
 //  AnalysisTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/PseudoDeviceAddressTests.swift
+++ b/herald/HeraldTests/PseudoDeviceAddressTests.swift
@@ -1,7 +1,7 @@
 //
 //  PseudoDeviceAddressTests.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/RssiHistogramTests.swift
+++ b/herald/HeraldTests/RssiHistogramTests.swift
@@ -1,0 +1,371 @@
+//
+//  RssiHistogramTests.swift
+//
+//  Copyright 2021 Herald Project Contributors
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Herald
+
+class RssiHistogramTests: XCTestCase {
+
+    private func printRange(_ rssiHistogram: RssiHistogram, _ min: Int, _ max: Int) {
+        for i in min...max {
+            print("\(i),\(rssiHistogram.normalise(Double(i)))")
+        }
+    }
+    
+    public func test_empty() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        
+        // Percentile values
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-32, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-54, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-55, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-77, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-32, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-54, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-55, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-77, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: Double.leastNonzeroMagnitude)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-100), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-50, rssiHistogram.normalise(-50), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-49, rssiHistogram.normalise(-49), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+    
+    public func test_zero_variance_10() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        rssiHistogram.add(-10)
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: Double.leastNonzeroMagnitude)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-100), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-50), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-49), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+
+    public func test_zero_variance_10_x2() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        rssiHistogram.add(-10)
+        rssiHistogram.add(-10)
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: Double.leastNonzeroMagnitude)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-100), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-50), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-49), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+
+    public func test_zero_variance_50() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        rssiHistogram.add(-50)
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: Double.leastNonzeroMagnitude)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-100), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-50), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-49), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+
+    public func test_zero_variance_50_x2() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        rssiHistogram.add(-50)
+        rssiHistogram.add(-50)
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-50, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: Double.leastNonzeroMagnitude)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-100), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-50), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-49), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+
+    public func test_identity() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        for rssi in (-98)...(-10) {
+            rssiHistogram.add(rssi)
+        }
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-32, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-54, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-55, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-76, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: 0.5);
+        XCTAssertEqual(-32, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: 0.5);
+        XCTAssertEqual(-54, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: 0.5);
+        XCTAssertEqual(-55, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: 0.5);
+        XCTAssertEqual(-76, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: 0.5);
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: 0.5);
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-100), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-50, rssiHistogram.normalise(-50), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-49, rssiHistogram.normalise(-49), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+
+    public func test_identity_x2() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        for rssi in (-98)...(-10) {
+            rssiHistogram.add(rssi)
+            rssiHistogram.add(rssi)
+        }
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-32, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-54, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-55, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-76, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: 0.5);
+        XCTAssertEqual(-32, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: 0.5);
+        XCTAssertEqual(-54, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: 0.5);
+        XCTAssertEqual(-55, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: 0.5);
+        XCTAssertEqual(-76, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: 0.5);
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: 0.5);
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-100), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-50, rssiHistogram.normalise(-50), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-49, rssiHistogram.normalise(-49), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+
+    public func test_upper_range() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        for rssi in (-44)...(-10) {
+            rssiHistogram.add(rssi)
+        }
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-18, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-27, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-27, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-36, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-44, rssiHistogram.samplePercentile(0.01))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: 0.5)
+        XCTAssertEqual(-30, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: 0.5)
+        XCTAssertEqual(-53, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: 0.5)
+        XCTAssertEqual(-53, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: 0.5)
+        XCTAssertEqual(-76, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: 0.5)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: 0.5)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-46), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-45), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-96, rssiHistogram.normalise(-44), accuracy: 0.5)
+        XCTAssertEqual(-53, rssiHistogram.normalise(-27), accuracy: 0.5)
+        XCTAssertEqual(-13, rssiHistogram.normalise(-11), accuracy: 0.5)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+    
+    public func test_upper_range_x2() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        for rssi in (-44)...(-10) {
+            rssiHistogram.add(rssi)
+            rssiHistogram.add(rssi)
+        }
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-10, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-18, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-27, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-27, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-36, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-44, rssiHistogram.samplePercentile(0.01))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: 0.5)
+        XCTAssertEqual(-30, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: 0.5)
+        XCTAssertEqual(-53, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: 0.5)
+        XCTAssertEqual(-53, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: 0.5)
+        XCTAssertEqual(-76, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: 0.5)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: 0.5)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-46), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-99, rssiHistogram.normalise(-45), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-96, rssiHistogram.normalise(-44), accuracy: 0.5)
+        XCTAssertEqual(-53, rssiHistogram.normalise(-27), accuracy: 0.5)
+        XCTAssertEqual(-13, rssiHistogram.normalise(-11), accuracy: 0.5)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-10), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+    
+    public func test_lower_range() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        for rssi in (-98)...(-45) {
+            rssiHistogram.add(rssi)
+        }
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-45, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-58, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-72, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-72, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-85, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-98, rssiHistogram.samplePercentile(0.01))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: 0.5)
+        XCTAssertEqual(-31, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: 0.5)
+        XCTAssertEqual(-55, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: 0.5)
+        XCTAssertEqual(-55, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: 0.5)
+        XCTAssertEqual(-76, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: 0.5)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: 0.5)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-97, rssiHistogram.normalise(-98), accuracy: 0.5)
+        XCTAssertEqual(-76, rssiHistogram.normalise(-85), accuracy: 0.5)
+        XCTAssertEqual(-55, rssiHistogram.normalise(-72), accuracy: 0.5)
+        XCTAssertEqual(-31, rssiHistogram.normalise(-58), accuracy: 0.5)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-45), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+
+    public func test_lower_range_x2() {
+        let rssiHistogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.zero, textFile: nil)
+        for rssi in (-98)...(-45) {
+            rssiHistogram.add(rssi)
+            rssiHistogram.add(rssi)
+        }
+        rssiHistogram.update()
+
+        // Percentile values
+        XCTAssertEqual(-45, rssiHistogram.samplePercentile(1.00))
+        XCTAssertEqual(-58, rssiHistogram.samplePercentile(0.75))
+        XCTAssertEqual(-72, rssiHistogram.samplePercentile(0.50))
+        XCTAssertEqual(-72, rssiHistogram.samplePercentile(0.49))
+        XCTAssertEqual(-85, rssiHistogram.samplePercentile(0.25))
+        XCTAssertEqual(-98, rssiHistogram.samplePercentile(0.01))
+        XCTAssertEqual(-99, rssiHistogram.samplePercentile(0.00))
+
+        // Normalisation extends value to full range
+        XCTAssertEqual(-10, rssiHistogram.normalise(rssiHistogram.samplePercentile(1.00)), accuracy: 0.5)
+        XCTAssertEqual(-31, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.75)), accuracy: 0.5)
+        XCTAssertEqual(-55, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.50)), accuracy: 0.5)
+        XCTAssertEqual(-55, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.49)), accuracy: 0.5)
+        XCTAssertEqual(-76, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.25)), accuracy: 0.5)
+        XCTAssertEqual(-99, rssiHistogram.normalise(rssiHistogram.samplePercentile(0.00)), accuracy: 0.5)
+
+        // Out of range values clamped to min and max
+        XCTAssertEqual(-99, rssiHistogram.normalise(-99), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-97, rssiHistogram.normalise(-98), accuracy: 0.5)
+        XCTAssertEqual(-76, rssiHistogram.normalise(-85), accuracy: 0.5)
+        XCTAssertEqual(-55, rssiHistogram.normalise(-72), accuracy: 0.5)
+        XCTAssertEqual(-31, rssiHistogram.normalise(-58), accuracy: 0.5)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-45), accuracy: Double.leastNonzeroMagnitude)
+        XCTAssertEqual(-10, rssiHistogram.normalise(-9), accuracy: Double.leastNonzeroMagnitude)
+    }
+}

--- a/herald/HeraldTests/SampleTests.swift
+++ b/herald/HeraldTests/SampleTests.swift
@@ -1,7 +1,7 @@
 //
 //  SampleTests.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/SelfCalibratedModelTests.swift
+++ b/herald/HeraldTests/SelfCalibratedModelTests.swift
@@ -1,0 +1,60 @@
+//
+//  SelfCalibratedModelTests.swift
+//
+//  Copyright 2021 Herald Project Contributors
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+
+
+import XCTest
+@testable import Herald
+
+class SelfCalibratedModelTests: XCTestCase {
+
+    public func test_uncalibrated() {
+        let model: SelfCalibratedModel = SelfCalibratedModel(min: Distance(0.2), mean: Distance(1), withinMin: TimeInterval.zero, withinMean: TimeInterval.hour * 12)
+        
+        model.map(value: Sample(secondsSinceUnixEpoch: 0, value: RSSI(-10)))
+        XCTAssertEqual(model.reduce()!, 0.2, accuracy: 0.1)
+
+        model.reset()
+        model.map(value: Sample(secondsSinceUnixEpoch: 0, value: RSSI(-54)))
+        XCTAssertEqual(model.reduce()!, 1.0, accuracy: 0.1)
+
+        model.reset()
+        model.map(value: Sample(secondsSinceUnixEpoch: 0, value: RSSI(-99)))
+        XCTAssertEqual(model.reduce()!, 1.8, accuracy: 0.1)
+    }
+
+    public func test_calibrated_range() {
+        for minRssi in -99...(-15) {
+            for maxRssi in (minRssi+4)...(-11) {
+                print("test_calibrated_range[\(minRssi),\(maxRssi)]");
+                test_calibrated_range(minRssi, maxRssi)
+            }
+        }
+    }
+
+    private func test_calibrated_range(_ minRssi: Int, _ maxRssi: Int) {
+        let midRssi = minRssi + (maxRssi - minRssi) / 2
+        let quarterRssi = minRssi + (maxRssi - minRssi) * 3 / 4
+        let model: SelfCalibratedModel = SelfCalibratedModel(min: Distance(0.2), mean: Distance(1), withinMin: TimeInterval.zero, withinMean: TimeInterval.hour * 12)
+        for rssi in minRssi...maxRssi {
+            model.histogram.add(rssi)
+        }
+        model.update()
+
+        model.map(value: Sample(secondsSinceUnixEpoch: 0, value: RSSI(maxRssi)))
+        XCTAssertEqual(model.reduce()!, 0.2, accuracy: 0.1)
+
+        model.reset()
+        model.map(value: Sample(secondsSinceUnixEpoch: 0, value: RSSI(quarterRssi)))
+        XCTAssertEqual(model.reduce()!, 0.6, accuracy: 0.2)
+
+        model.reset()
+        model.map(value: Sample(secondsSinceUnixEpoch: 0, value: RSSI(midRssi)))
+        XCTAssertEqual(model.reduce()!, 1.0, accuracy: 0.1)
+    }
+
+}

--- a/herald/HeraldTests/SimplePayloadDataMatcherTests.swift
+++ b/herald/HeraldTests/SimplePayloadDataMatcherTests.swift
@@ -1,7 +1,7 @@
 //
 //  SimplePayloadDataMatcherTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
+++ b/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
@@ -1,7 +1,7 @@
 //
 //  SimplePayloadDataSupplierTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/SocialDistanceTests.swift
+++ b/herald/HeraldTests/SocialDistanceTests.swift
@@ -1,7 +1,7 @@
 ////
 //  SocialDistanceTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/TextFileTests.swift
+++ b/herald/HeraldTests/TextFileTests.swift
@@ -1,0 +1,45 @@
+//
+//  TextFileTests.swift
+//
+//  Copyright 2021 Herald Project Contributors
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Herald
+
+class TextFileTests: XCTestCase {
+
+    func testEmpty() {
+        let textFile = TextFile(filename: "empty.txt")
+        XCTAssertTrue(textFile.empty())
+        XCTAssertEqual(textFile.contentsOf(), "")
+    }
+
+    func testWriteOneLine() {
+        let textFile = TextFile(filename: "oneLine.txt")
+        textFile.overwrite("")
+        textFile.write("line1")
+        XCTAssertFalse(textFile.empty())
+        XCTAssertEqual(textFile.contentsOf(), "line1\n")
+    }
+
+    func testWriteTwoLines() {
+        let textFile = TextFile(filename: "twoLine.txt")
+        textFile.overwrite("")
+        textFile.write("line1")
+        textFile.write("line2")
+        XCTAssertFalse(textFile.empty())
+        XCTAssertEqual(textFile.contentsOf(), "line1\nline2\n")
+    }
+
+    func testOverwrite() {
+        let textFile = TextFile(filename: "overwrite.txt")
+        textFile.overwrite("")
+        XCTAssertTrue(textFile.empty())
+        textFile.overwrite("line1")
+        XCTAssertEqual(textFile.contentsOf(), "line1")
+        textFile.overwrite("line2")
+        XCTAssertEqual(textFile.contentsOf(), "line2")
+    }
+}

--- a/herald/HeraldTests/VenueDiaryEventTests.swift
+++ b/herald/HeraldTests/VenueDiaryEventTests.swift
@@ -1,7 +1,7 @@
 //
 //  VenueDiaryEventTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/HeraldTests/VenueDiaryTests.swift
+++ b/herald/HeraldTests/VenueDiaryTests.swift
@@ -1,7 +1,7 @@
 //
 //  VenueDiaryTests.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Analysis/Algorithms/Distance/SelfCalibratedModel.swift
+++ b/herald/herald/Sensor/Analysis/Algorithms/Distance/SelfCalibratedModel.swift
@@ -1,0 +1,272 @@
+//
+//  SelfCalibratedModel.swift
+//
+//  Copyright 2021 Herald Project Contributors
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Extension of SmoothedLinearModel to include self-calibration
+/// - Assume minimum and average distance between people for entire population is
+///   similar over time (e.g. weeks and months).
+/// - Experiments have shown advertised TX power for all test phones are similar
+///   while the measured RSSI by different phones differs at the same distance.
+/// - Normalisation of measured RSSI value is required to bring all receivers to
+///   a common range, and then use the minimum and median value to determine the
+///   intercept and coefficient.
+/// - Histogram normalisation is enabled by a long term histogram of all measured
+///   RSSI values by a device.
+/// - Use social norm to set minimum and mean distance between people, then set
+///   time duration within minimum and mean distance to derive percentiles for
+///   self-calibration based on observed values.
+public class SelfCalibratedModel: SmoothedLinearModel {
+    private let logger = ConcreteSensorLogger(subsystem: "Sensor", category: "Analysis.Algorithms.Distance.SelfCalibratedModel")
+    private let min: Distance
+    private let mean: Distance
+    private let maxRssiPercentile: Double
+    private let anchorRssiPercentile: Double
+    public let histogram: RssiHistogram
+    private var maxRssi: Double = -10
+    private var lastSampleTime: Date = Date(timeIntervalSince1970: 0)
+
+    public init(min: Distance, mean: Distance, withinMin: TimeInterval, withinMean: TimeInterval, textFile: TextFile? = nil) {
+        self.min = min
+        self.mean = mean
+        self.maxRssiPercentile = (TimeInterval.day - withinMin) / TimeInterval.day
+        self.anchorRssiPercentile = (TimeInterval.day - withinMean) / TimeInterval.day
+        self.histogram = RssiHistogram(min: -99, max: -10, updatePeriod: TimeInterval.minute * 10, textFile: textFile)
+        super.init()
+    }
+
+    public func update() {
+        histogram.update()
+        // Use max RSSI percentile (e.g. 95th) value for minimum distance
+        maxRssi = histogram.normalisedPercentile(maxRssiPercentile)
+        // Use anchor RSSI percentile (e.g. 50th, median) value as marker for average distance.
+        let anchorRssi = histogram.normalisedPercentile(anchorRssiPercentile)
+        // Use value range between mean and max as estimate for coefficient
+        let rssiRange = maxRssi - anchorRssi
+        // Estimate intercept and coefficient (default derived from SmoothedLinearModel)
+        intercept = maxRssi
+        coefficient = (rssiRange > 0 ? (mean.value - min.value) / rssiRange : 0.266793)
+        logger.debug("update (maxRSSI=\(maxRssi),anchorRSSI=\(anchorRssi),intercept=\(intercept),coefficient=\(coefficient))")
+    }
+
+    public override func map(value: Sample) {
+        super.map(value: value)
+        if (value.taken > lastSampleTime) {
+            histogram.add(value.value.value)
+            lastSampleTime = value.taken
+        }
+    }
+    
+    public override func reduce() -> Double? {
+        // Update model
+        update()
+        guard let sampleMedian = medianOfRssi() else {
+            logger.debug("reduce, sample median is nil")
+            return nil
+        }
+        let normalisedMedian = histogram.normalise(sampleMedian)
+        if normalisedMedian < -99 {
+            logger.debug("reduce, out of range (reason=tooFar,median=\(normalisedMedian),minRssi=-99)")
+            return nil
+        }
+        if normalisedMedian > maxRssi {
+            logger.debug("reduce, out of range (reason=tooNear,median=\(normalisedMedian),maxRssi=\(maxRssi)")
+            return nil
+        }
+        let distanceInMetres = min.value + (intercept - normalisedMedian) * coefficient
+        guard distanceInMetres > 0 else {
+            logger.debug("reduce, out of range (reason=tooNear,median=\(normalisedMedian),distance=\(distanceInMetres))")
+            return nil
+        }
+        return distanceInMetres
+    }
+}
+
+
+/// Accumulate histogram of all RSSI measurements to build
+/// a profile of the receiver for normalisation
+public class RssiHistogram: SensorDelegate {
+    public let min: Int
+    public let max: Int
+    public var histogram: [Int64]
+    private var cdf: [Int64]
+    private var transform: [Double]
+    private let textFile: TextFile?
+    private let updatePeriod: TimeInterval
+    private var lastUpdateTime: Date = Date(timeIntervalSince1970: 0)
+    private var samples: Int64 = 0
+    public var description: String { get {
+        return "RssiHistogram{samples=\(samples),p05=\(samplePercentile(0.05)),p50=\(samplePercentile(0.5)),p95=\(samplePercentile(0.95))}"
+    }}
+
+
+    /// Accumulate histogram of RSSI for value range [min, max] and auto-write profile to storage at regular intervals
+    public init(min: Int, max: Int, updatePeriod: TimeInterval = TimeInterval.minute, textFile: TextFile? = nil) {
+        self.min = min;
+        self.max = max;
+        self.histogram = Array<Int64>(repeating: 0, count: Int(max - min + 1))
+        self.cdf = Array<Int64>(repeating: 0, count: histogram.count)
+        self.transform = Array<Double>(repeating: 0, count: histogram.count)
+        self.textFile = textFile
+        self.updatePeriod = updatePeriod
+        clear()
+        guard let textFile = textFile else {
+            return
+        }
+        read(textFile)
+        update()
+    }
+    
+    public func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {
+        // Guard for data collection until histogram reaches maximum count
+        // Deliberately using Int64.max to mirror Android implementation
+        guard samples < Int64.max else {
+            return
+        }
+        // Guard for RSSI measurements only
+        guard didMeasure.unit == .RSSI else {
+            return
+        }
+        add(didMeasure.value)
+    }
+
+    /// Add RSSI sample
+    public func add(_ rssi: Int) {
+        guard rssi >= min, rssi <= max else {
+            return
+        }
+        // Increment count
+        let index = rssi - min
+        histogram[index] += 1
+        samples += 1
+        // Update at regular intervals
+        let time = Date()
+        if lastUpdateTime.secondsSinceUnixEpoch + Int64(updatePeriod) < time.secondsSinceUnixEpoch {
+            if let textFile = textFile {
+                write(textFile)
+            }
+            update()
+            lastUpdateTime = time
+        }
+    }
+    
+    public func add(_ rssiValue: Double) {
+        // Guard for RSSI range
+        let rssi = Int(round(rssiValue))
+        add(rssi)
+    }
+
+    public func clear() {
+        for i in 0...histogram.count-1 {
+            histogram[i] = 0
+            cdf[i] = 0
+        }
+        for i in 0...transform.count-1 {
+            transform[i] = Double(i)
+        }
+        samples = 0
+    }
+
+    public func samplePercentile(_ percentile: Double) -> Int {
+        if samples == 0 {
+            return min + Int(round(Double(max - min) * percentile))
+        }
+        let percentileCount = Double(samples) * percentile
+        for i in 0...cdf.count-1 {
+            if Double(cdf[i]) >= percentileCount {
+                return Int(min + i)
+            }
+        }
+        return Int(max)
+    }
+
+    public func normalisedPercentile(_ percentile: Double) -> Double {
+        return normalise(Double(samplePercentile(percentile)))
+    }
+
+    /// Read profile data from storage, this replaces existing in-memory profile
+    public func read(_ textFile: TextFile) {
+        clear()
+        let content = textFile.contentsOf()
+        for row in content.split(separator: "\n") {
+            let cols = row.split(separator: ",", maxSplits: 2)
+            guard cols.count == 2 else {
+                continue
+            }
+            guard let rssi = Int(cols[0]), let count = Int64(cols[1]) else {
+                continue
+            }
+            guard rssi >= min, rssi <= max else {
+                continue
+            }
+            let index = rssi - min
+            histogram[index] = count
+            samples += count
+        }
+    }
+
+    /// Render profile data as CSV (RSSI,count)
+    private func toCsv() -> String {
+        var s = ""
+        for i in 0...histogram.count-1 {
+            let rssi = min + i
+            let row = "\(rssi),\(histogram[i])\n"
+            s += row
+        }
+        return s
+    }
+
+    /// Write profile data to storage
+    public func write(_ textFile: TextFile) {
+        let content = toCsv()
+        textFile.overwrite(content)
+    }
+
+    // MARK: - Histogram equalisation
+
+    /// Compute cumulative distribution function (CDF) of histogram
+    private static func cumulativeDistributionFunction(_ histogram: [Int64], _ cdf: inout [Int64]) {
+        var sum = Int64(0)
+        for i in 0...histogram.count-1 {
+            sum += histogram[i]
+            cdf[i] = sum
+        }
+    }
+
+    /// Compute transformation table for normalising histogram to maximise its dynamic range
+    private static func normalisation(_ cdf: [Int64], _ transform: inout [Double]) {
+        let sum = Double(cdf[cdf.count - 1])
+        let max = Double(cdf.count - 1)
+        if sum > 0 {
+            for i in 0...cdf.count-1 {
+                transform[i] = max * Double(cdf[i]) / sum
+            }
+        }
+    }
+
+    public func update() {
+        RssiHistogram.cumulativeDistributionFunction(histogram, &cdf)
+        RssiHistogram.normalisation(cdf, &transform)
+    }
+
+    // MARK: - Normalisation
+    
+    public func normalise(_ rssi: Int) -> Double {
+        normalise(Double(rssi))
+    }
+
+    public func normalise(_ rssi: Double) -> Double {
+        let index = Int(round(rssi - Double(min)))
+        guard index >= 0 else {
+            return Double(min) + transform[0]
+        }
+        guard index < transform.count else {
+            return Double(min) + transform.last!
+        }
+        return Double(min) + transform[index]
+    }
+}

--- a/herald/herald/Sensor/Analysis/Algorithms/Distance/SmoothedLinearModel.swift
+++ b/herald/herald/Sensor/Analysis/Algorithms/Distance/SmoothedLinearModel.swift
@@ -89,10 +89,6 @@ public class SmoothedLinearModel: Aggregate {
     public func medianOfRssi() -> Double? {
         return median.reduce()
     }
-    
-    public func maximumRssi() -> Double {
-        return -intercept / coefficient
-    }
 }
 
 
@@ -139,8 +135,8 @@ public class SmoothedLinearModelAnalyser: AnalysisProvider {
         }
         // Estimate distance based on smoothed linear model
         model.reset()
-        guard let distance = window.aggregate([model]).get(SmoothedLinearModel.self) else {
-            logger.debug("analyse, skipped (reason=outOfModelRange,mediaOfRssi=\(String(describing: model.medianOfRssi())),maximumRssiAtZeroDistance=\(model.maximumRssi()))")
+        guard let distance = window.aggregate([model]).get(0) else {
+            logger.debug("analyse, skipped (reason=outOfModelRange,mediaOfRssi=\(String(describing: model.medianOfRssi()))")
             return false
         }
         // Publish distance data

--- a/herald/herald/Sensor/Analysis/Algorithms/Distance/SmoothedLinearModel.swift
+++ b/herald/herald/Sensor/Analysis/Algorithms/Distance/SmoothedLinearModel.swift
@@ -45,8 +45,8 @@ public class SmoothedLinearModel: Aggregate {
     override var runs: Int { get { 1 }}
     private var run: Int = 1
     private let median: Median = Median()
-    public let intercept: Double
-    public let coefficient: Double
+    public var intercept: Double
+    public var coefficient: Double
     public static let defaultIntercept: Double = -17.102080
     public static let defaultCoefficient: Double = -0.266793
     
@@ -105,10 +105,10 @@ public class SmoothedLinearModelAnalyser: AnalysisProvider {
     private var lastRan: Date = Date(timeIntervalSince1970: 0)
     private let valid: Filter = InRange(-99, -10)
 
-    public init(interval: TimeInterval = 4, smoothingWindow: TimeInterval = TimeInterval.minute, intercept: Double = SmoothedLinearModel.defaultIntercept, coefficient: Double = SmoothedLinearModel.defaultCoefficient) {
+    public init(interval: TimeInterval = 4, smoothingWindow: TimeInterval = TimeInterval.minute, model: SmoothedLinearModel = SmoothedLinearModel()) {
         self.interval = Int64(interval)
         self.smoothingWindow = Int64(smoothingWindow)
-        self.model = SmoothedLinearModel(intercept: intercept, coefficient: coefficient)
+        self.model = model
         super.init(ValueType(describing: RSSI.self), ValueType(describing: Distance.self))
     }
 

--- a/herald/herald/Sensor/Analysis/Interactions.swift
+++ b/herald/herald/Sensor/Analysis/Interactions.swift
@@ -1,7 +1,7 @@
 //
 //  Interactions.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Analysis/Mobility.swift
+++ b/herald/herald/Sensor/Analysis/Mobility.swift
@@ -1,7 +1,7 @@
 //
 //  Mobility.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: MIT
 //
 

--- a/herald/herald/Sensor/Analysis/SampleStatistics.swift
+++ b/herald/herald/Sensor/Analysis/SampleStatistics.swift
@@ -1,7 +1,7 @@
 //
 //  SampleStatistics.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Analysis/Sampling/AnalysisProvider.swift
+++ b/herald/herald/Sensor/Analysis/Sampling/AnalysisProvider.swift
@@ -30,7 +30,7 @@ public class AnalysisProviderManager {
     private var providers: [AnalysisProvider] = []
     private let queue = DispatchQueue(label: "Sensor.Analysis.Sampling.AnalysisProviderManager")
 
-    public init(_ providers: [AnalysisProvider]) {
+    public init(_ providers: [AnalysisProvider] = []) {
         providers.forEach({ add($0) })
     }
     

--- a/herald/herald/Sensor/Analysis/SocialDistance.swift
+++ b/herald/herald/Sensor/Analysis/SocialDistance.swift
@@ -1,7 +1,7 @@
 //
 //  SocialDistance.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Analysis/VenueDiary.swift
+++ b/herald/herald/Sensor/Analysis/VenueDiary.swift
@@ -1,7 +1,7 @@
 //
 //  VenueDiary.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/BLE/BLEAdvertParser.swift
+++ b/herald/herald/Sensor/BLE/BLEAdvertParser.swift
@@ -1,7 +1,7 @@
 //
 //  BLEAdvertParser.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -1,7 +1,7 @@
 //
 //  BLEDatabase.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -1,7 +1,7 @@
 //
 //  BLEReceiver.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -1,7 +1,7 @@
 //
 //  BLESensor.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/BLE/BLETransmitter.swift
+++ b/herald/herald/Sensor/BLE/BLETransmitter.swift
@@ -1,7 +1,7 @@
 //
 //  BLETransmitter.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/BLE/BLEUtilities.swift
+++ b/herald/herald/Sensor/BLE/BLEUtilities.swift
@@ -1,7 +1,7 @@
 //
 //  BLEUtilities.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/BatteryLog.swift
+++ b/herald/herald/Sensor/Data/BatteryLog.swift
@@ -1,7 +1,7 @@
 //
 //  BatteryLog.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/CalibrationLog.swift
+++ b/herald/herald/Sensor/Data/CalibrationLog.swift
@@ -1,7 +1,7 @@
 //
 //  CalibrationLog.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/ContactLog.swift
+++ b/herald/herald/Sensor/Data/ContactLog.swift
@@ -1,7 +1,7 @@
 //
 //  ContactLog.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/DetectionLog.swift
+++ b/herald/herald/Sensor/Data/DetectionLog.swift
@@ -1,7 +1,7 @@
 //
 //  DetectionLog.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/EventLog.swift
+++ b/herald/herald/Sensor/Data/EventLog.swift
@@ -1,7 +1,7 @@
 //
 //  EventLog.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: MIT
 //
 

--- a/herald/herald/Sensor/Data/EventTimeIntervalLog.swift
+++ b/herald/herald/Sensor/Data/EventTimeIntervalLog.swift
@@ -1,7 +1,7 @@
 //
 //  EventTimeIntervalLog.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/PayloadDataFormatter.swift
+++ b/herald/herald/Sensor/Data/PayloadDataFormatter.swift
@@ -1,7 +1,7 @@
 //
 //  PayloadDataFormatter.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: MIT
 //
 

--- a/herald/herald/Sensor/Data/SensorLogger.swift
+++ b/herald/herald/Sensor/Data/SensorLogger.swift
@@ -1,7 +1,7 @@
 //
 //  Logger.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/StatisticsLog.swift
+++ b/herald/herald/Sensor/Data/StatisticsLog.swift
@@ -1,7 +1,7 @@
 //
 //  StatisticsLog.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Data/TextFile.swift
+++ b/herald/herald/Sensor/Data/TextFile.swift
@@ -12,7 +12,7 @@ public class TextFile {
     let url: URL?
     private let queue: DispatchQueue
     
-    init(filename: String) {
+    public init(filename: String) {
         url = try? FileManager.default
         .url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         .appendingPathComponent(filename)

--- a/herald/herald/Sensor/Data/TextFile.swift
+++ b/herald/herald/Sensor/Data/TextFile.swift
@@ -19,11 +19,31 @@ public class TextFile {
         queue = DispatchQueue(label: "Sensor.Data.TextFile(\(filename))")
     }
     
+    /// Get contents of file
+    func contentsOf() -> String {
+        queue.sync {
+            guard let file = url else {
+                return ""
+            }
+            guard let contents = try? String(contentsOf: file, encoding: .utf8) else {
+                return ""
+            }
+            return contents
+        }
+    }
+    
     func empty() -> Bool {
         guard let file = url else {
             return true
         }
-        return !FileManager.default.fileExists(atPath: file.path)
+        guard FileManager.default.fileExists(atPath: file.path) else {
+            return true
+        }
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: file.path),
+              let size = attributes[FileAttributeKey.size] as? UInt64 else {
+            return true
+        }
+        return size == 0
     }
     
     /// Append line to new or existing file

--- a/herald/herald/Sensor/Data/TextFile.swift
+++ b/herald/herald/Sensor/Data/TextFile.swift
@@ -1,7 +1,7 @@
 //
 //  TextFile.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Datatype/DoubleValue.swift
+++ b/herald/herald/Sensor/Datatype/DoubleValue.swift
@@ -15,6 +15,10 @@ public class DoubleValue: CustomStringConvertible {
     public init(_ value: Double) {
         self.value = value
     }
+
+    public init(_ value: Int) {
+        self.value = Double(value)
+    }
 }
 
 /// Received signal strength indicator (RSSI)

--- a/herald/herald/Sensor/Device.swift
+++ b/herald/herald/Sensor/Device.swift
@@ -1,7 +1,7 @@
 //
 //  Device.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Extensions/DataExtensions.swift
+++ b/herald/herald/Sensor/Extensions/DataExtensions.swift
@@ -1,7 +1,7 @@
 //
 //  DataExtensions.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: MIT
 //
 

--- a/herald/herald/Sensor/Extensions/DateExtensions.swift
+++ b/herald/herald/Sensor/Extensions/DateExtensions.swift
@@ -1,7 +1,7 @@
 //
 //  DateExtensions.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Location/MobilitySensor.swift
+++ b/herald/herald/Sensor/Location/MobilitySensor.swift
@@ -1,7 +1,7 @@
 //
 //  MobilitySensor.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Motion/InertiaSensor.swift
+++ b/herald/herald/Sensor/Motion/InertiaSensor.swift
@@ -1,7 +1,7 @@
 ////
 //  InertiaSensor.swift
 //
-//  Copyright 2021 VMware, Inc.
+//  Copyright 2021 Herald Project Contributors
 //  SPDX-License-Identifier: MIT
 //
 

--- a/herald/herald/Sensor/Payload/Beacon/BeaconPayloadDataSupplier.swift
+++ b/herald/herald/Sensor/Payload/Beacon/BeaconPayloadDataSupplier.swift
@@ -1,7 +1,7 @@
 //
 //  BeaconPayloadDataSupplier.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Payload/Extended/ExtendedData.swift
+++ b/herald/herald/Sensor/Payload/Extended/ExtendedData.swift
@@ -1,7 +1,7 @@
 //
 //  ExtendedData.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Payload/Simple/BloomFilter.swift
+++ b/herald/herald/Sensor/Payload/Simple/BloomFilter.swift
@@ -1,7 +1,7 @@
 //
 //  BloomFilter.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Payload/Simple/SimplePayloadDataMatcher.swift
+++ b/herald/herald/Sensor/Payload/Simple/SimplePayloadDataMatcher.swift
@@ -1,7 +1,7 @@
 //
 //  SonarPayloadDataIdentifier.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
+++ b/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
@@ -1,7 +1,7 @@
 //
 //  SimplePayloadDataSupplier.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Payload/Simple/XXH3.swift
+++ b/herald/herald/Sensor/Payload/Simple/XXH3.swift
@@ -1,7 +1,7 @@
 //
 //  XXH3.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 //  Adapted from xxHash-Swift created by Daisuke T

--- a/herald/herald/Sensor/Payload/Test/TestPayloadDataSupplier.swift
+++ b/herald/herald/Sensor/Payload/Test/TestPayloadDataSupplier.swift
@@ -1,7 +1,7 @@
 //
 //  TestPayloadDataSupplier.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/PayloadDataMatcher.swift
+++ b/herald/herald/Sensor/PayloadDataMatcher.swift
@@ -1,7 +1,7 @@
 //
 //  PayloadDataMatcher.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/PayloadDataSupplier.swift
+++ b/herald/herald/Sensor/PayloadDataSupplier.swift
@@ -1,7 +1,7 @@
 //
 //  PayloadDataSupplier.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/Sensor.swift
+++ b/herald/herald/Sensor/Sensor.swift
@@ -1,7 +1,7 @@
 //
 //  Sensor.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -1,7 +1,7 @@
 //
 //  SensorArray.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -1,7 +1,7 @@
 //
 //  SensorDelegate.swift
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 

--- a/herald/herald/herald.h
+++ b/herald/herald/herald.h
@@ -1,7 +1,7 @@
 //
 //  Herald.h
 //
-//  Copyright 2020 VMware, Inc.
+//  Copyright 2020-2021 Herald Project Contributors
 //  SPDX-License-Identifier: Apache-2.0
 //
 


### PR DESCRIPTION
- Changed copyright from VMware to Herald Project Contributors
- Self-calibrated SmoothLinearModel for distance estimation based on social norms
- Demonstration of self-calibration assumes social norms (under 3.7 metres for up to 8 hours/day)
- Absolute measurements on GUI shall be incorrect if the phones are static and unusually close to each other for long periods (e.g. artificial lab test), this is expected behaviour
- Relative measurements on GUI shall be unstable if the phones have been static for most of the test period (e.g. artificial lab test), this is expected behaviour
- Distance update has a 30 second delay due to smoothing over 1 minute time window
- Recommended test procedure is to carry the test phone on person to enable self-calibration based on a realistic distribution of RSSI values
- GUI update to match with Android
- Passes all unit tests
- Tested on iPhone X with Pixel 2 and Pixel 3

closes #134 
